### PR TITLE
Terminus station setting

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,7 +7,7 @@
   <!-- Replace the default version if something was set for it -->
   <PropertyGroup Condition="'$(AssemblyVersion)' == '' OR '$(MajorVersion)' != '' OR '$(MinorVersion)' != ''">
     <MajorVersion Condition="'$(MajorVersion)' == ''">0</MajorVersion>
-    <MinorVersion Condition="'$(MinorVersion)' == ''">5</MinorVersion>
+    <MinorVersion Condition="'$(MinorVersion)' == ''">6</MinorVersion>
     <PatchVersion Condition="'$(PatchVersion)' == ''">0</PatchVersion>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</AssemblyVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,7 +7,7 @@
   <!-- Replace the default version if something was set for it -->
   <PropertyGroup Condition="'$(AssemblyVersion)' == '' OR '$(MajorVersion)' != '' OR '$(MinorVersion)' != ''">
     <MajorVersion Condition="'$(MajorVersion)' == ''">0</MajorVersion>
-    <MinorVersion Condition="'$(MinorVersion)' == ''">6</MinorVersion>
+    <MinorVersion Condition="'$(MinorVersion)' == ''">7</MinorVersion>
     <PatchVersion Condition="'$(PatchVersion)' == ''">0</PatchVersion>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</AssemblyVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>

--- a/PassengerHelper/PassengerHelperPlugin.cs
+++ b/PassengerHelper/PassengerHelperPlugin.cs
@@ -24,6 +24,13 @@ namespace PassengerHelperPlugin
         private readonly IModDefinition self;
         internal IUIHelper UIHelper { get; }
         internal Dictionary<string, PassengerLocomotiveSettings> passengerLocomotivesSettings { get; }
+        internal Dictionary<BaseLocomotive, PassengerLocomotive> _locomotives = new();
+
+        internal readonly List<string> orderedStations = new List<string>()
+                {
+                "sylva", "dillsboro", "wilmot", "whittier", "ela", "bryson", "hemingway", "alarkajct", "cochran", "alarka",
+                "almond", "nantahala", "topton", "rhodo", "andrews"
+                };
         public PassengerHelperPlugin(IModdingContext ctx, IModDefinition self, IUIHelper uiHelper)
         {
             new Harmony(self.Id).PatchAll(GetType().Assembly);

--- a/PassengerHelper/Patches/AutoEngineerPassengerStopperPatch.cs
+++ b/PassengerHelper/Patches/AutoEngineerPassengerStopperPatch.cs
@@ -25,7 +25,6 @@ using RollingStock;
 using Game.Notices;
 using Support;
 
-
 [HarmonyPatch]
 public static class AutoEngineerPassengerStopperPatches
 {
@@ -131,9 +130,9 @@ public static class AutoEngineerPassengerStopperPatches
         // get terminus stations
         List<string> terminusStations = settings.Stations.Where(station => station.Value.TerminusStation == true).Select(station => station.Key).OrderBy(d => plugin.orderedStations.IndexOf(d)).ToList();
 
-        if (terminusStations.Count > 2)
+        if (terminusStations.Count != 2)
         {
-            logger.Information("there are more than 2 terminus stations");
+            logger.Information("there are not exactly 2 terminus stations");
             // continue normal logic
             return true;
         }
@@ -174,7 +173,7 @@ public static class AutoEngineerPassengerStopperPatches
         passengerLocomotive.AtTerminusStationEast = false;
 
         logger.Information("Not at either terminus station, so there are more stops, continuing.");
-        logger.Information("Ensureing at least 1 passenger car has a terminus station selected");
+        logger.Information("Ensuring at least 1 passenger car has a terminus station selected");
         foreach (Car coach in coaches)
         {
             PassengerMarker? marker = coach.GetPassengerMarker();
@@ -194,7 +193,7 @@ public static class AutoEngineerPassengerStopperPatches
         if (_nextStop?.identifier == "alarka" && !settings.LoopMode)
         {
             logger.Information("Train is in Alarka, there are more stops, and loop mode is not activated. Reversing train.");
-            ReverseLocoDirection(_locomotive);
+            passengerLocomotive.ReverseLocoDirection();
         }
     }
 
@@ -243,7 +242,7 @@ public static class AutoEngineerPassengerStopperPatches
 
         Say($"{Hyperlink.To(_locomotive)} reversing direction.");
         // reverse the direction of the loco
-        ReverseLocoDirection(_locomotive);
+        passengerLocomotive.ReverseLocoDirection();
 
         return false;
     }

--- a/PassengerHelper/Patches/AutoEngineerPassengerStopperPatch.cs
+++ b/PassengerHelper/Patches/AutoEngineerPassengerStopperPatch.cs
@@ -58,7 +58,11 @@ public static class AutoEngineerPassengerStopperPatches
             passengerLocomotive = new PassengerLocomotive(_locomotive, _settings);
             plugin._locomotives.Add(_locomotive, passengerLocomotive);
         }
-
+        PassengerLocomotiveSettings settings = passengerLocomotive.Settings;
+        if (settings.Disable)
+        {
+            return true;
+        }
 
         if (_nextStop != passengerLocomotive.CurrentStop)
         {
@@ -78,7 +82,6 @@ public static class AutoEngineerPassengerStopperPatches
         }
 
         passengerLocomotive.ResetStoppedFlags();
-        PassengerLocomotiveSettings settings = passengerLocomotive.Settings;
 
         if (!CheckFuelLevels(passengerLocomotive, _locomotive, settings, _nextStop))
         {
@@ -236,7 +239,7 @@ public static class AutoEngineerPassengerStopperPatches
         // if we don't want to reverse, return to orignal logic
         if (settings.LoopMode)
         {
-            logger.Information("Setting to disable reversing at last station is set to true. Continuing in current direction.");
+            logger.Information("Loop Mode is set to true. Continuing in current direction.");
             return true;
         }
 

--- a/PassengerHelper/Patches/PassengerStopPatch.cs
+++ b/PassengerHelper/Patches/PassengerStopPatch.cs
@@ -34,7 +34,7 @@ public static class PassengerStopPatches
                 if (passengerLocomotive.CurrentStop != __instance)
                 {
                     logger.Information("Train {0} has not stopped at {1} yet, waiting to unload cars until it stops", engine.DisplayName, __instance.DisplayName);
-                    __result = false;
+                    // __result = false;
                 }
                 break;
             }

--- a/PassengerHelper/Patches/PassengerStopPatch.cs
+++ b/PassengerHelper/Patches/PassengerStopPatch.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Linq;
+using HarmonyLib;
+using Model;
+using Model.Definition;
+using PassengerHelperPlugin.Support;
+using RollingStock;
+using Serilog;
+
+namespace PassengerHelperPlugin.Patches;
+
+[HarmonyPatch]
+public static class PassengerStopPatches
+{
+
+    static readonly Serilog.ILogger logger = Log.ForContext(typeof(PassengerStopPatches));
+
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(PassengerStop), "ShouldWorkCar")]
+    private static void ShouldWorkCar(ref bool __result, Car car, PassengerStop __instance)
+    {
+        PassengerHelperPlugin plugin = PassengerHelperPlugin.Shared;
+        if (!plugin.IsEnabled)
+        {
+            return;
+        }
+
+        IEnumerable<Car> engines = car.EnumerateCoupled().Where(car => car.Archetype == CarArchetype.LocomotiveSteam || car.Archetype == CarArchetype.LocomotiveDiesel);
+
+        foreach (Car engine in engines)
+        {
+            if (plugin._locomotives.TryGetValue((BaseLocomotive)engine, out PassengerLocomotive passengerLocomotive))
+            {
+                if (passengerLocomotive.CurrentStop != __instance)
+                {
+                    logger.Information("Train {0} has not stopped at {1} yet, waiting to unload cars until it stops", engine.DisplayName, __instance.DisplayName);
+                    __result = false;
+                }
+                break;
+            }
+        }
+
+    }
+}

--- a/PassengerHelper/Support/PassengerLocomotive.cs
+++ b/PassengerHelper/Support/PassengerLocomotive.cs
@@ -22,7 +22,8 @@ public class PassengerLocomotive
     public bool StoppedForDiesel = false;
     public bool StoppedForCoal = false;
     public bool StoppedForWater = false;
-    public bool AtLastStop = false;
+    public bool AtTerminusStationEast = false;
+    public bool AtTerminusStationWest = false;
     private readonly BaseLocomotive _locomotive;
     private readonly bool hasTender = false;
     public bool HasMoreStops = false;
@@ -170,7 +171,7 @@ public class PassengerLocomotive
             }
         }
 
-        if (AtLastStop && Settings.WaitForFullPassengersLastStation)
+        if (AtTerminusStationWest && Settings.WaitForFullPassengersLastStation)
         {
             logger.Information("Checking to see if all passenger cars are full");
             IEnumerable<Car> coaches = _locomotive.EnumerateCoupled().Where(car => car.Archetype == CarArchetype.Coach);
@@ -191,7 +192,7 @@ public class PassengerLocomotive
                     }
                 }
             }
-            AtLastStop = false;
+            AtTerminusStationWest = false;
         }
 
         // for sandbox use, check every time

--- a/PassengerHelper/Support/PassengerLocomotive.cs
+++ b/PassengerHelper/Support/PassengerLocomotive.cs
@@ -20,6 +20,7 @@ public class PassengerLocomotive
 {
     readonly ILogger logger = Log.ForContext(typeof(PassengerLocomotive));
     public bool CurrentlyStopped = false;
+    public bool Continue = false;
     public string CurrentReasonForStop = "";
     public bool StoppedForDiesel = false;
     public bool StoppedForCoal = false;
@@ -142,6 +143,11 @@ public class PassengerLocomotive
     public bool ShouldStayStopped()
     {
         logger.Information("checking if {0} should stay Stopd at current station", _locomotive.DisplayName);
+        if (Continue)
+        {
+            logger.Information("Continue button clicked. Continuing", _locomotive.DisplayName);
+            return false;
+        }
         // train was requested to remain stopped
         if (Settings.StopAtNextStation || Settings.StopAtLastStation)
         {
@@ -173,7 +179,7 @@ public class PassengerLocomotive
             }
         }
 
-        if (AtTerminusStationWest && Settings.WaitForFullPassengersLastStation)
+        if ((AtTerminusStationWest || AtTerminusStationEast) && Settings.WaitForFullPassengersLastStation)
         {
             logger.Information("Checking to see if all passenger cars are full");
             IEnumerable<Car> coaches = _locomotive.EnumerateCoupled().Where(car => car.Archetype == CarArchetype.Coach);

--- a/PassengerHelper/Support/PassengerLocomotive.cs
+++ b/PassengerHelper/Support/PassengerLocomotive.cs
@@ -6,11 +6,13 @@ using System.Linq;
 using Game;
 using Game.State;
 using Model;
+using Model.AI;
 using Model.Definition;
 using Model.Definition.Data;
 using Model.OpsNew;
 using RollingStock;
 using Serilog;
+using UI.EngineControls;
 using static Model.Car;
 
 
@@ -186,7 +188,8 @@ public class PassengerLocomotive
                     LoadSlot loadSlot = coach.Definition.LoadSlots.FirstOrDefault((LoadSlot slot) => slot.RequiredLoadIdentifier == "passengers");
                     int maxCapacity = (int)loadSlot.MaximumCapacity;
                     PassengerMarker actualMarker = marker.Value;
-                    if(actualMarker.TotalPassengers < maxCapacity) {
+                    if (actualMarker.TotalPassengers < maxCapacity)
+                    {
                         logger.Information("Passenger car not full, remaining stopped");
                         return true;
                     }
@@ -204,6 +207,13 @@ public class PassengerLocomotive
         }
 
         return StoppedForDiesel || StoppedForCoal || StoppedForWater;
+    }
+
+    public void ReverseLocoDirection()
+    {
+        AutoEngineerPersistence persistence = new(_locomotive.KeyValueObject);
+        AutoEngineerOrdersHelper helper = new(_locomotive, persistence);
+        helper.SetOrdersValue(null, !persistence.Orders.Forward);
     }
 
     private Car FuelCar()

--- a/PassengerHelper/Support/PassengerLocomotiveSettings.cs
+++ b/PassengerHelper/Support/PassengerLocomotiveSettings.cs
@@ -17,6 +17,7 @@ public class PassengerLocomotiveSettings
     public bool PointToPointMode { get; set; } = true;
     public bool LoopMode { get; set; } = false;
     public bool WaitForFullPassengersLastStation { get; set; } = false;
+    public bool Disable { get; set; } = false; 
 
     public SortedDictionary<string, StationSetting> Stations { get; } = new() {
             { "sylva", new StationSetting() },

--- a/PassengerHelper/Support/PassengerLocomotiveSettings.cs
+++ b/PassengerHelper/Support/PassengerLocomotiveSettings.cs
@@ -10,8 +10,11 @@ using System.Threading.Tasks;
 public class PassengerLocomotiveSettings
 {
     public bool StopForDiesel { get; set; } = false;
+    public float DieselLevel { get; set; } = 0.10f;
     public bool StopForCoal { get; set; } = false;
+    public float CoalLevel { get; set; } = 0.10f;
     public bool StopForWater { get; set; } = false;
+    public float WaterLevel { get; set; } = 0.10f;
     public bool StopAtNextStation { get; set; } = false;
     public bool StopAtLastStation { get; set; } = false;
     public bool PointToPointMode { get; set; } = true;

--- a/PassengerHelper/Support/PassengerLocomotiveSettings.cs
+++ b/PassengerHelper/Support/PassengerLocomotiveSettings.cs
@@ -37,12 +37,20 @@ public class PassengerLocomotiveSettings
         };
 }
 
-public class StationSetting {
-    public bool include = false;
-    public StationAction stationAction = StationAction.Normal;
+public class StationSetting
+{
+    public bool include { get; set; } = false;
+    public StationAction stationAction { get; set; } = StationAction.Normal;
+    public bool TerminusStation { get; set; } = false;
+
+    public override string ToString()
+    {
+        return "StationSetting[ include=" + include + ", stationAction=" + stationAction + ", TerminusStation=" + TerminusStation + "]";
+    }
 }
 
-public enum StationAction {
+public enum StationAction
+{
     Normal,
     Pause
 }

--- a/PassengerHelper/Support/PassengerSettingsWindow.cs
+++ b/PassengerHelper/Support/PassengerSettingsWindow.cs
@@ -186,6 +186,20 @@ public class PassengerSettingsWindow
         }).FlexibleWidth(1f);
         builder.HStack(delegate (UIPanelBuilder builder)
         {
+            builder.AddToggle(() => passengerLocomotiveSettings.Disable, delegate (bool on)
+            {
+                logger.Information("Disable set to {0}", on);
+                passengerLocomotiveSettings.Disable = on;
+            }).Tooltip("Enabled", $"Toggle whether PassengerHelper should be disabled or not")
+            .Width(25f);
+            builder.AddLabel("Disable", delegate (TMP_Text text)
+            {
+                text.textWrappingMode = TextWrappingModes.NoWrap;
+                text.overflowMode = TextOverflowModes.Ellipsis;
+            }).FlexibleWidth(1f);
+        });
+        builder.HStack(delegate (UIPanelBuilder builder)
+        {
             builder.AddToggle(() => passengerLocomotiveSettings.StopForDiesel, delegate (bool on)
             {
                 logger.Information("Stop for Diesel set to {0}", on);

--- a/PassengerHelper/Support/PassengerSettingsWindow.cs
+++ b/PassengerHelper/Support/PassengerSettingsWindow.cs
@@ -129,14 +129,7 @@ public class PassengerSettingsWindow
                 }).Width(175f);
                 builder.AddToggle(() => passengerLocomotiveSettings.Stations[name].TerminusStation, delegate (bool on)
                 {
-                    int numTerminusStations = 0;
-                    passengerLocomotiveSettings.Stations.Values.ToList().ForEach(s =>
-                    {
-                        if (s.TerminusStation == true)
-                        {
-                            numTerminusStations++;
-                        }
-                    });
+                    int numTerminusStations = passengerLocomotiveSettings.Stations.Values.Where(s => s.TerminusStation == true).Count();
 
                     logger.Information("There are currently {0} terminus stations set", numTerminusStations);
                     if (numTerminusStations >= 2 && on == true)

--- a/PassengerHelper/Support/PassengerSettingsWindow.cs
+++ b/PassengerHelper/Support/PassengerSettingsWindow.cs
@@ -15,9 +15,6 @@ using UnityEngine;
 
 public class PassengerSettingsWindow
 {
-    private static Window? passengerSettingsWindow;
-    
-
     static readonly Serilog.ILogger logger = Log.ForContext(typeof(PassengerSettingsWindow));
     public static void Show(Car car)
     {
@@ -31,17 +28,15 @@ public class PassengerSettingsWindow
         }
 
         IUIHelper uIHelper = plugin.UIHelper;
-        if (passengerSettingsWindow == null)
+        Window passengerSettingsWindow = uIHelper.CreateWindow(500, 250, Window.Position.Center);
+        passengerSettingsWindow.OnShownDidChange += (s) =>
         {
-            passengerSettingsWindow = uIHelper.CreateWindow(500, 250, Window.Position.Center);
-            passengerSettingsWindow.OnShownDidChange += (s) =>
+            if (!s)
             {
-                if (!s)
-                {
-                    plugin.SaveSettings();
-                }
-            };
-        }
+                plugin.SaveSettings();
+            }
+        };
+
         passengerSettingsWindow.Title = "Passenger Helper Settings for " + _locomotive.DisplayName;
 
         if (!plugin.passengerLocomotivesSettings.TryGetValue(locomotiveName, out PassengerLocomotiveSettings passengerLocomotiveSettings))
@@ -60,7 +55,7 @@ public class PassengerSettingsWindow
             builder.VStack(delegate (UIPanelBuilder builder)
             {
                 logger.Information("Populating stations for {0}", _locomotive.DisplayName);
-                PopulateStations(uIHelper, builder, passengerLocomotiveSettings, plugin);
+                PopulateStations(passengerSettingsWindow, uIHelper, builder, passengerLocomotiveSettings, plugin);
                 builder.AddExpandingVerticalSpacer();
             });
 
@@ -70,6 +65,18 @@ public class PassengerSettingsWindow
                 logger.Information("Populating settings for {0}", _locomotive.DisplayName);
                 PopulateSettings(builder, passengerLocomotiveSettings, plugin);
                 builder.AddExpandingVerticalSpacer();
+            });
+            builder.VStack(delegate (UIPanelBuilder builder)
+            {
+                builder.AddExpandingVerticalSpacer();
+                builder.HStack(delegate (UIPanelBuilder builder)
+                {
+                    builder.Spacer().FlexibleWidth(1f);
+                    builder.AddButton("Save Settings", () =>
+                    {
+                        passengerSettingsWindow.CloseWindow();
+                    });
+                });
             });
         });
         passengerSettingsWindow.ShowWindow();
@@ -83,7 +90,7 @@ public class PassengerSettingsWindow
         .ToList();
     }
 
-    private static void PopulateStations(IUIHelper uIHelper, UIPanelBuilder builder, PassengerLocomotiveSettings passengerLocomotiveSettings, PassengerHelperPlugin plugin)
+    private static void PopulateStations(Window passengerSettingsWindow, IUIHelper uIHelper, UIPanelBuilder builder, PassengerLocomotiveSettings passengerLocomotiveSettings, PassengerHelperPlugin plugin)
     {
         builder.AddLabel("Station Stops:", delegate (TMP_Text text)
         {
@@ -210,7 +217,29 @@ public class PassengerSettingsWindow
             {
                 text.textWrappingMode = TextWrappingModes.NoWrap;
                 text.overflowMode = TextOverflowModes.Ellipsis;
+            }).Width(200f);
+            builder.AddInputField((passengerLocomotiveSettings.DieselLevel * 100).ToString(), delegate (string val)
+            {
+                if (float.TryParse(val, out float value))
+                {
+                    if (value < 0 || value > 100)
+                    {
+                        logger.Information("Entered a Diesel Level greater than 100 or lower than 0");
+                        return;
+                    }
+
+                    passengerLocomotiveSettings.DieselLevel = value / 100;
+                }
+            }, null, 2)
+            .Tooltip("Diesel Level Percentage", "Set the percentage of diesel remaining should trigger a stop for low diesel")
+            .Width(50f)
+            .Height(20f);
+            builder.AddLabel("%", delegate (TMP_Text text)
+            {
+                text.textWrappingMode = TextWrappingModes.NoWrap;
+                text.overflowMode = TextOverflowModes.Ellipsis;
             }).FlexibleWidth(1f);
+            builder.Spacer();
         });
         builder.HStack(delegate (UIPanelBuilder builder)
         {
@@ -224,7 +253,29 @@ public class PassengerSettingsWindow
             {
                 text.textWrappingMode = TextWrappingModes.NoWrap;
                 text.overflowMode = TextOverflowModes.Ellipsis;
+            }).Width(200f);
+            builder.AddInputField((passengerLocomotiveSettings.CoalLevel * 100).ToString(), delegate (string val)
+            {
+                if (float.TryParse(val, out float value))
+                {
+                    if (value < 0 || value > 100)
+                    {
+                        logger.Information("Entered a Coal Level greater than 100 or lower than 0");
+                        return;
+                    }
+
+                    passengerLocomotiveSettings.CoalLevel = value / 100;
+                }
+            }, null, 2)
+            .Tooltip("Coal Level Percentage", "Set the percentage of coal remaining should trigger a stop for low coal")
+            .Width(50f)
+            .Height(20f);
+            builder.AddLabel("%", delegate (TMP_Text text)
+            {
+                text.textWrappingMode = TextWrappingModes.NoWrap;
+                text.overflowMode = TextOverflowModes.Ellipsis;
             }).FlexibleWidth(1f);
+            builder.Spacer();
         });
         builder.HStack(delegate (UIPanelBuilder builder)
             {
@@ -238,7 +289,29 @@ public class PassengerSettingsWindow
                 {
                     text.textWrappingMode = TextWrappingModes.NoWrap;
                     text.overflowMode = TextOverflowModes.Ellipsis;
+                }).Width(200f);
+                builder.AddInputField((passengerLocomotiveSettings.WaterLevel * 100).ToString(), delegate (string val)
+            {
+                if (float.TryParse(val, out float value))
+                {
+                    if (value < 0 || value > 100)
+                    {
+                        logger.Information("Entered a Water Level greater than 100 or lower than 0");
+                        return;
+                    }
+
+                    passengerLocomotiveSettings.WaterLevel = value / 100;
+                }
+            }, null, 2)
+            .Tooltip("Water Level Percentage", "Set the percentage of water remaining should trigger a stop for low water")
+            .Width(50f)
+            .Height(20f);
+                builder.AddLabel("%", delegate (TMP_Text text)
+                {
+                    text.textWrappingMode = TextWrappingModes.NoWrap;
+                    text.overflowMode = TextOverflowModes.Ellipsis;
                 }).FlexibleWidth(1f);
+                builder.Spacer();
             });
         builder.HStack(delegate (UIPanelBuilder builder)
         {


### PR DESCRIPTION
## Features
- Added terminus setting. This will now define the "last stop" rather than previously, where the last stop was based on whether the attatched passenger cars had station selections on them or not. Note that you must choose 2 terminus stations. Not doing so will result in effectively falling back to default game behavior.
- Added Disable setting. This will completely disable passengerhelper for the selected engine.
- Added Continue button. This will allow you to have an engine continue from a station, effectively ignoring all the reasons for pausing there.
- Add configurable percentages to the diesel, coal and water settings. You can enter values 0 to 99 which translate to percent under the hood.
- PassengerHelper Settings Windows can now be open for each engine simotaneously, rather than previously where it was just one at a time.
- Added SaveSettings button to Settings Window, clicking it will save the settings and close the window.
- Modified the size of the car inscpetor window. It will change to the new size once you go to the Orders tab.

## Bug Fixes
- Fixed bug with the title of the PassengerHelper Settings displaying the wrong loco name. This was purely a visual bug, but it is now fixed.
- With the terminus settings, it <i>might</i> be the case that modded passenger cars and engines will now work. I cannot confirm nor deny this, so still continue to use at your own risk.